### PR TITLE
[7.59.x] BXMSPROD-1418: add new DDL Scripts into the distributed assembly

### DIFF
--- a/src/main/assembly/process-migration-distribution.xml
+++ b/src/main/assembly/process-migration-distribution.xml
@@ -7,11 +7,15 @@
     <formats>
         <format>zip</format>
     </formats>
-
+    <baseDirectory>/</baseDirectory>
     <fileSets>
         <fileSet>
             <directory>target/quarkus-app</directory>
-            <outputDirectory>.</outputDirectory>
+            <outputDirectory>process-migration-service</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>ddl-scripts</directory>
+            <outputDirectory>ddl-scripts</outputDirectory>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

Backport for https://github.com/kiegroup/process-migration-service/pull/15 into 7.59.x