### PR TITLE
[JBPM-9892] - Any exception thrown while starting up container should be caught

### DIFF
--- a/src/test/java/org/kie/processmigration/test/ContainerKieServerLifecycleManager.java
+++ b/src/test/java/org/kie/processmigration/test/ContainerKieServerLifecycleManager.java
@@ -96,7 +96,7 @@ public class ContainerKieServerLifecycleManager implements QuarkusTestResourceLi
             props.put("kieservers[0].username", "kieserver");
             props.put("kieservers[0].password", "kieserver1!");
             return props;
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             LOGGER.warn("Unable to start Docker container for: {}:{}", CONTAINER_IMAGE, CONTAINER_TAG, e);
         }
         Iterator<String> propNames = ConfigProvider.getConfig().getPropertyNames().iterator();


### PR DESCRIPTION
**[JBPM-9892](https://issues.redhat.com/browse/JBPM-9892)**: Any exception thrown while starting up container should be caught

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

</details>
