### PR TITLE
[7.59.x][JBPM-9892] - Any exception thrown while starting up container should be caught

### DIFF
--- a/src/test/java/org/kie/processmigration/test/ContainerKieServerLifecycleManager.java
+++ b/src/test/java/org/kie/processmigration/test/ContainerKieServerLifecycleManager.java
@@ -96,7 +96,7 @@ public class ContainerKieServerLifecycleManager implements QuarkusTestResourceLi
             props.put("kieservers[0].username", "kieserver");
             props.put("kieservers[0].password", "kieserver1!");
             return props;
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             LOGGER.warn("Unable to start Docker container for: {}:{}", CONTAINER_IMAGE, CONTAINER_TAG, e);
         }
         Iterator<String> propNames = ConfigProvider.getConfig().getPropertyNames().iterator();


### PR DESCRIPTION
Backport of https://github.com/kiegroup/process-migration-service/pull/17