### PR TITLE
[7.59.x][BXMSPROD-1475] GHA maven version

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,22 +18,24 @@ jobs:
     strategy:
       matrix:
         java-version: [11]
+        maven-version: ['3.8.1']
       fail-fast: true
     runs-on: ubuntu-latest
     name: Maven Build
     steps:
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Setup Maven And Java Version
+        uses: s4u/setup-maven-action@v1.2.1
         with:
           java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ matrix.java-version }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
-      - name: Build Chain ${{ matrix.java-version }}
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
+      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.4
         with:


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1475

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1774
* https://github.com/kiegroup/kie-soup/pull/229
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/551
* https://github.com/kiegroup/drools/pull/3837
* https://github.com/kiegroup/optaplanner/pull/1579
* https://github.com/kiegroup/lienzo-core/pull/153
* https://github.com/kiegroup/lienzo-tests/pull/127
* https://github.com/kiegroup/appformer/pull/1198
* https://github.com/kiegroup/kie-uberfire-extensions/pull/125
* https://github.com/kiegroup/jbpm/pull/2027
* https://github.com/kiegroup/kie-jpmml-integration/pull/66
* https://github.com/kiegroup/droolsjbpm-integration/pull/2608
* https://github.com/kiegroup/kie-wb-playground/pull/120
* https://github.com/kiegroup/kie-wb-common/pull/3687
* https://github.com/kiegroup/drools-wb/pull/1516
* https://github.com/kiegroup/jbpm-designer/pull/919
* https://github.com/kiegroup/jbpm-work-items/pull/217
* https://github.com/kiegroup/jbpm-wb/pull/1517
* https://github.com/kiegroup/optaplanner-wb/pull/406
* https://github.com/kiegroup/kie-wb-distributions/pull/1131
* https://github.com/kiegroup/openshift-drools-hacep/pull/119
* https://github.com/kiegroup/process-migration-service/pull/25
* https://github.com/kiegroup/optaweb-employee-rostering/pull/692
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/562
* https://github.com/kiegroup/kie-docs/pull/3895
