### PR TITLE
[7.59.x][JBPM-9919] - Update PIM to use Quarkus 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <version.com.fasterxml.jackson.core.jackson-databind>2.10.5.1</version.com.fasterxml.jackson.core.jackson-databind>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
-    <version.io.quarkus>2.2.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.2.3.Final</version.io.quarkus>
     <version.org.github.tomakehurst.wiremock-jre8>2.27.2</version.org.github.tomakehurst.wiremock-jre8>
     <version.org.kie.server>${project.version}</version.org.kie.server>
     <version.org.mockito>3.7.7</version.org.mockito>


### PR DESCRIPTION
Backport of https://github.com/kiegroup/process-migration-service/pull/28