### PR TITLE
[7.67.x][Rhpam-4028] Allow migrate large number of instances

### DIFF
--- a/frontend/src/__tests__/tabMigrationPlan/PageMigrationRunningInstances.test.js
+++ b/frontend/src/__tests__/tabMigrationPlan/PageMigrationRunningInstances.test.js
@@ -1,18 +1,29 @@
 import renderer from "react-test-renderer";
 import React from "react";
-import PageMigrationRunningInstances from "../../component/tabMigrationPlan/wizardExecuteMigration/PageMigrationRunningInstances";
+import PageMigrationRunningInstances
+  from "../../component/tabMigrationPlan/wizardExecuteMigration/PageMigrationRunningInstances";
 import running_instances from "../../../mock_data/running_instances.json";
 
 test("PageMigrationRunningInstances renders correctly using snapshot", () => {
   const myMock = jest.fn();
+  const getRunningInstancesFn = jest.fn(() => {
+    return new Promise(function (resolve) {
+      resolve({
+        data: running_instances,
+        headers: [{ "x-total-count": 31 }]
+      })
+    })
+  });
   const tree = renderer
     .create(
       <PageMigrationRunningInstances
-        runningInstances={running_instances}
+        getRunningInstances={getRunningInstancesFn}
         setRunningInstancesIds={myMock}
         onIsValid={myMock}
+        migrateAll={false}
       />
     )
     .toJSON();
   expect(tree).toMatchSnapshot();
+  expect(getRunningInstancesFn).toBeCalledTimes(1);
 });

--- a/frontend/src/__tests__/tabMigrationPlan/__snapshots__/PageMigrationRunningInstances.test.js.snap
+++ b/frontend/src/__tests__/tabMigrationPlan/__snapshots__/PageMigrationRunningInstances.test.js.snap
@@ -12,7 +12,7 @@ exports[`PageMigrationRunningInstances renders correctly using snapshot 1`] = `
       <tr>
         <th
           aria-label="ID"
-          className="sorting sort sort-none"
+          className="sorting_asc sort sort-asc"
           colSpan={1}
           index={0}
           onClick={[Function]}
@@ -22,7 +22,7 @@ exports[`PageMigrationRunningInstances renders correctly using snapshot 1`] = `
         </th>
         <th
           aria-label="Name"
-          className="sorting_asc sort sort-asc"
+          className="sorting sort sort-none"
           colSpan={1}
           index={1}
           onClick={[Function]}
@@ -62,194 +62,7 @@ exports[`PageMigrationRunningInstances renders correctly using snapshot 1`] = `
         </th>
       </tr>
     </thead>
-    <tbody>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          2
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:06:55:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          3
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:30:23:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          4
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:49:27:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          5
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:49:34:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          6
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:58:54:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-      <tr
-        className=""
-        onClick={[Function]}
-        role="row"
-      >
-        <td
-          className=""
-        >
-          7
-        </td>
-        <td
-          className=""
-        >
-          Evaluation
-        </td>
-        <td
-          className=""
-        >
-          mockup_Evaluation
-        </td>
-        <td
-          className=""
-        >
-          2019-01-06T21:59:04:123Z
-        </td>
-        <td
-          className=""
-        >
-          Active
-        </td>
-      </tr>
-    </tbody>
+    <tbody />
   </table>
   <form
     className="content-view-pf-pagination table-view-pf-pagination clearfix"
@@ -347,9 +160,7 @@ exports[`PageMigrationRunningInstances renders correctly using snapshot 1`] = `
          
         <span
           className="pagination-pf-items-total"
-        >
-          31
-        </span>
+        />
       </span>
       <ul
         className="pagination pagination-pf-back"
@@ -401,7 +212,7 @@ exports[`PageMigrationRunningInstances renders correctly using snapshot 1`] = `
         <span
           className="pagination-pf-pages"
         >
-          6
+          NaN
         </span>
       </span>
       <ul

--- a/frontend/src/clients/kieServerClient.js
+++ b/frontend/src/clients/kieServerClient.js
@@ -21,15 +21,25 @@ class KieServerClient extends BaseClient {
       .then(res => res.data);
   }
 
-  getInstances(kieServerId, containerId, page, pageSize) {
-    return this.instance
-      .get(this.buildUrl(kieServerId, "instances", containerId), {
+  getInstances(
+    kieServerId,
+    containerId,
+    page,
+    pageSize,
+    sortingColumn,
+    sortingOrder
+  ) {
+    return this.instance.get(
+      this.buildUrl(kieServerId, "instances", containerId),
+      {
         params: {
-          page,
-          pageSize
+          page: page - 1,
+          pageSize,
+          sortBy: sortingColumn,
+          orderBy: sortingOrder
         }
-      })
-      .then(res => res.data);
+      }
+    );
   }
 }
 

--- a/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
+++ b/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
@@ -41,7 +41,9 @@ import org.kie.processmigration.service.KieService;
 public class KieServiceResource {
 
     private static final String DEFAULT_PAGE = "0";
-    private static final String DEFAULT_PAGE_SIZE = "1000";
+    private static final String DEFAULT_PAGE_SIZE = "100";
+    private static final String DEFAULT_SORT_COLUMN = "processInstanceId";
+    private static final String DEFAULT_SORT_ORDER = "asc";
 
     @Inject
     KieService kieService;
@@ -61,9 +63,9 @@ public class KieServiceResource {
     @GET
     @Path("/{kieServerId}/definitions/{containerId}/{processId}")
     public Response getDefinition(
-        @PathParam("kieServerId") String kieServerId,
-        @PathParam("containerId") String containerId,
-        @PathParam("processId") String processId
+            @PathParam("kieServerId") String kieServerId,
+            @PathParam("containerId") String containerId,
+            @PathParam("processId") String processId
     ) throws InvalidKieServerException {
         try {
             ProcessInfo definition = kieService.getDefinition(kieServerId, new ProcessRef().setContainerId(containerId).setProcessId(processId));
@@ -78,8 +80,13 @@ public class KieServiceResource {
     public Response getRunningInstances(@PathParam("kieServerId") String kieServerId,
                                         @PathParam("containerId") String containerId,
                                         @DefaultValue(DEFAULT_PAGE) @QueryParam("page") Integer page,
-                                        @DefaultValue(DEFAULT_PAGE_SIZE) @QueryParam("pageSize") Integer pageSize) throws InvalidKieServerException {
-        List<RunningInstance> result = kieService.getRunningInstances(kieServerId, containerId, page, pageSize);
-        return Response.ok(result).build();
+                                        @DefaultValue(DEFAULT_PAGE_SIZE) @QueryParam("pageSize") Integer pageSize,
+                                        @DefaultValue(DEFAULT_SORT_COLUMN) @QueryParam("sortBy") String sortBy,
+                                        @DefaultValue(DEFAULT_SORT_ORDER) @QueryParam("orderBy") String orderBy) throws InvalidKieServerException {
+        List<RunningInstance> result = kieService.getRunningInstances(kieServerId, containerId, page, pageSize, sortBy, orderBy);
+        Integer total = kieService.countRunningInstances(kieServerId, containerId);
+        return Response.ok(result)
+                .header("X-Total-Count", total)
+                .build();
     }
 }

--- a/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
+++ b/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
@@ -84,7 +84,7 @@ public class KieServiceResource {
                                         @DefaultValue(DEFAULT_SORT_COLUMN) @QueryParam("sortBy") String sortBy,
                                         @DefaultValue(DEFAULT_SORT_ORDER) @QueryParam("orderBy") String orderBy) throws InvalidKieServerException {
         List<RunningInstance> result = kieService.getRunningInstances(kieServerId, containerId, page, pageSize, sortBy, orderBy);
-        Integer total = kieService.countRunningInstances(kieServerId, containerId);
+        Long total = kieService.countRunningInstances(kieServerId, containerId);
         return Response.ok(result)
                 .header("X-Total-Count", total)
                 .build();

--- a/src/main/java/org/kie/processmigration/service/KieService.java
+++ b/src/main/java/org/kie/processmigration/service/KieService.java
@@ -47,7 +47,9 @@ public interface KieService {
 
     boolean existsProcessDefinition(String kieServerId, ProcessRef processRef) throws InvalidKieServerException;
 
-    List<RunningInstance> getRunningInstances(String kieServerId, String containerId, Integer page, Integer pageSize) throws InvalidKieServerException;
+    List<RunningInstance> getRunningInstances(String kieServerId, String containerId, Integer page, Integer pageSize, String sortBy, String orderBy) throws InvalidKieServerException;
+
+    Integer countRunningInstances(String kieServerId, String containerId) throws InvalidKieServerException;
 
     KieServicesClient getClient(String kieServerId) throws InvalidKieServerException;
 }

--- a/src/main/java/org/kie/processmigration/service/KieService.java
+++ b/src/main/java/org/kie/processmigration/service/KieService.java
@@ -49,7 +49,7 @@ public interface KieService {
 
     List<RunningInstance> getRunningInstances(String kieServerId, String containerId, Integer page, Integer pageSize, String sortBy, String orderBy) throws InvalidKieServerException;
 
-    Integer countRunningInstances(String kieServerId, String containerId) throws InvalidKieServerException;
+    Long countRunningInstances(String kieServerId, String containerId) throws InvalidKieServerException;
 
     KieServicesClient getClient(String kieServerId) throws InvalidKieServerException;
 }

--- a/src/main/java/org/kie/processmigration/service/impl/KieServiceImpl.java
+++ b/src/main/java/org/kie/processmigration/service/impl/KieServiceImpl.java
@@ -47,12 +47,16 @@ import org.kie.processmigration.model.exceptions.CredentialsException;
 import org.kie.processmigration.model.exceptions.InvalidKieServerException;
 import org.kie.processmigration.model.exceptions.ProcessDefinitionNotFoundException;
 import org.kie.processmigration.service.KieService;
+import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.definition.ProcessDefinition;
+import org.kie.server.api.model.definition.QueryDefinition;
+import org.kie.server.api.model.definition.QueryFilterSpec;
 import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.util.QueryFilterSpecBuilder;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesFactory;
@@ -83,6 +87,11 @@ public class KieServiceImpl implements KieService {
     private static final long AWAIT_EXECUTOR = 5;
     private static final long RETRY_DELAY = 2;
     private static final Logger logger = LoggerFactory.getLogger(KieServiceImpl.class);
+    private static final String QUERY_COUNT_ALL_RUNNING_INSTANCES = "countAllRunningInstances";
+    private static final String JDBC_JBPM_DS = "java:jboss/datasources/ExampleDS";
+    private static final String QUERY_TARGET = "CUSTOM";
+    private static final String DEFAULT_SORT_COLUMN = "processInstanceId";
+    private static final String DESC_SORT_ORDER = "desc";
 
     private CredentialsProvider credentialsProvider = CredentialsProviderFinder.find("quarkus.file.vault");
     final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
@@ -146,10 +155,12 @@ public class KieServiceImpl implements KieService {
     }
 
     @Override
-    public List<RunningInstance> getRunningInstances(String kieServerId, String containerId, Integer page, Integer
-            pageSize) throws InvalidKieServerException {
+    public List<RunningInstance> getRunningInstances(String kieServerId, String containerId, Integer page,
+                                                     Integer pageSize, String sortBy, String orderBy)
+            throws InvalidKieServerException {
         ProcessServicesClient processServicesClient = getProcessServicesClient(kieServerId);
-        List<ProcessInstance> instanceList = processServicesClient.findProcessInstances(containerId, page, pageSize);
+        List<ProcessInstance> instanceList = processServicesClient.findProcessInstances(containerId, page, pageSize,
+                translateSortColumn(sortBy), getOrderBy(orderBy));
 
         int i = 0;
         List<RunningInstance> result = new ArrayList<>();
@@ -159,6 +170,40 @@ public class KieServiceImpl implements KieService {
         }
 
         return result;
+    }
+
+    // Default to process-instance-id
+    private String translateSortColumn(String column) {
+        if(column == null) {
+            return DEFAULT_SORT_COLUMN;
+        }
+        switch (column) {
+            case "name": return "processName";
+            case "description": return "processInstanceDescription";
+            case "startTime": return "start_date";
+            case "state": return "log.status";
+            default: return DEFAULT_SORT_COLUMN;
+        }
+    }
+
+    // Default to ASC
+    private Boolean getOrderBy(String orderBy) {
+        return !DESC_SORT_ORDER.equalsIgnoreCase(orderBy);
+    }
+
+    @Override
+    public Integer countRunningInstances(String kieServerId, String containerId) throws InvalidKieServerException {
+        QueryFilterSpec filter = new QueryFilterSpecBuilder()
+                .equalsTo("externalId", containerId)
+                .get();
+        List<List> queryRes = getQueryServicesClient(kieServerId)
+                .query(QUERY_COUNT_ALL_RUNNING_INSTANCES,
+                        QueryServicesClient.QUERY_MAP_RAW,
+                        filter, 0, 1, List.class);
+        if (queryRes.isEmpty() || queryRes.get(0).isEmpty()) {
+            return 0;
+        }
+        return ((Double) queryRes.get(0).get(0)).intValue();
     }
 
     @Override
@@ -260,7 +305,41 @@ public class KieServiceImpl implements KieService {
             retryConnection(kieConfig);
         }
         configs.add(kieConfig);
-        logger.info("Loaded kie server configuration for: {}", config);
+        registerCustomQueries(kieConfig);
+        logger.info("Loaded kie server configuration for: {}", kieConfig);
+    }
+
+    private void registerCustomQueries(KieServerConfig config) {
+        if (config.getClient() == null) {
+            return;
+        }
+        try {
+            QueryServicesClient querySvc = getQueryServicesClient(config.getId());
+            QueryDefinition query = null;
+            try {
+                query = querySvc.getQuery(QUERY_COUNT_ALL_RUNNING_INSTANCES);
+            } catch (KieServicesException e) {
+                logger.debug("Error trying to fetch query {} in {}", QUERY_COUNT_ALL_RUNNING_INSTANCES, config.getId());
+            }
+            if (query == null) {
+                logger.debug("Query {} does not exist in {}. Registering it.", QUERY_COUNT_ALL_RUNNING_INSTANCES, config.getId());
+                QueryDefinition countAllRunningInstancesQuery = new QueryDefinition.Builder()
+                        .name(QUERY_COUNT_ALL_RUNNING_INSTANCES)
+                        .source(JDBC_JBPM_DS)
+                        .expression("select count (*) as total, log.externalId \n" +
+                                "from\n" +
+                                "  ProcessInstanceLog log\n" +
+                                "group by log.externalId")
+                        .target(QUERY_TARGET)
+                        .build();
+                querySvc.registerQuery(countAllRunningInstancesQuery);
+                logger.debug("Registered custom query {} for {}", QUERY_COUNT_ALL_RUNNING_INSTANCES, config.getId());
+            } else {
+                logger.debug("Query {} already exists in {}", QUERY_COUNT_ALL_RUNNING_INSTANCES, config.getId());
+            }
+        } catch (InvalidKieServerException e) {
+            logger.error("Unable to register custom queries for {}", config.getId(), e);
+        }
     }
 
     private KieServicesClient createKieServicesClient(KieServerConfig config) {

--- a/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
+++ b/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
@@ -180,7 +180,9 @@ class ProcessMigrationIT extends AbstractBaseIT {
     }
 
     private void assertCount(int size, String kieServerId, String containerId) {
-        given().get("/" + kieServerId + "/instances/" + containerId)
+        given().auth()
+                .basic(PIM_USERNAME, PIM_PASSWORD)
+                .get("/" + kieServerId + "/instances/" + containerId)
                 .then()
                 .statusCode(200)
                 .header("X-Total-Count", String.valueOf(size));

--- a/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
+++ b/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
@@ -182,7 +182,7 @@ class ProcessMigrationIT extends AbstractBaseIT {
     private void assertCount(int size, String kieServerId, String containerId) {
         given().auth()
                 .basic(PIM_USERNAME, PIM_PASSWORD)
-                .get("/" + kieServerId + "/instances/" + containerId)
+                .get("/rest/kieservers/" + kieServerId + "/instances/" + containerId)
                 .then()
                 .statusCode(200)
                 .header("X-Total-Count", String.valueOf(size));

--- a/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
+++ b/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
@@ -15,37 +15,35 @@
  */
 package org.kie.processmigration.integration;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 
-import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.appformer.maven.integration.MavenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.api.KieServices;
 import org.kie.processmigration.model.Execution;
 import org.kie.processmigration.model.Migration;
 import org.kie.processmigration.model.MigrationDefinition;
 import org.kie.processmigration.model.Plan;
 import org.kie.processmigration.model.ProcessRef;
-import org.kie.processmigration.model.exceptions.InvalidKieServerException;
-import org.kie.processmigration.service.KieService;
-import org.kie.processmigration.test.Profiles;
+import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServiceResponse;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesFactory;
 import org.kie.server.client.ProcessServicesClient;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.RestAssured;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,14 +53,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.kie.processmigration.test.ContainerKieServerLifecycleManager.ARTIFACT_ID;
-import static org.kie.processmigration.test.ContainerKieServerLifecycleManager.CONTAINER_ID;
-import static org.kie.processmigration.test.ContainerKieServerLifecycleManager.GROUP_ID;
-import static org.kie.processmigration.test.ContainerKieServerLifecycleManager.KIE_SERVER_ID;
 
-@QuarkusTest
-@TestProfile(Profiles.KieServerIntegrationProfile.class)
-class ProcessMigrationIT {
+class ProcessMigrationIT extends AbstractBaseIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -72,31 +64,30 @@ class ProcessMigrationIT {
     private static final String SOURCE_CONTAINER_ID = "test_1.0.0";
     private static final String TARGET_CONTAINER_ID = "test_2.0.0";
 
-    @ConfigProperty(name = "pim.username")
-    String username;
-
-    @ConfigProperty(name = "pim.password")
-    String password;
-
-    @Inject
-    KieService kieService;
-
-    @Inject
-    ObjectMapper mapper;
+    private KieServicesClient kieClient;
+    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
 
     @BeforeEach
-    void deployProcesses() throws Exception {
-        KieServicesClient client = kieService.getClient(KIE_SERVER_ID);
+    void deployProcesses() throws IOException {
+        kieClient = createClient();
+        KieServices ks = KieServices.Factory.get();
+        MavenRepository repo = MavenRepository.getMavenRepository();
         for (String version : List.of("1.0.0", "2.0.0")) {
+
+            org.kie.api.builder.ReleaseId builderReleaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, version);
+            File kjar = readFile(CONTAINER_ID + "-" + version + ".jar");
+            File pom = readFile(CONTAINER_ID + "-" + version + ".pom");
+            repo.installArtifact(builderReleaseId, kjar, pom);
+
             ReleaseId releaseId = new ReleaseId(GROUP_ID, ARTIFACT_ID, version);
             KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-            ServiceResponse<KieContainerResource> response = client.createContainer(CONTAINER_ID + "_" + version, resource);
+            ServiceResponse<KieContainerResource> response = kieClient.createContainer(CONTAINER_ID + "_" + version, resource);
             assertThat(response.getType(), is(KieServiceResponse.ResponseType.SUCCESS));
         }
     }
 
     @Test
-    void testBasicMigration() throws InvalidKieServerException, IOException {
+    void testBasicMigration() throws IOException {
         // Given
         startProcesses();
 
@@ -104,23 +95,24 @@ class ProcessMigrationIT {
         createMigration();
 
         // Then
-        ProcessServicesClient processClient = kieService.getClient(KIE_SERVER_ID).getServicesClient(ProcessServicesClient.class);
+        ProcessServicesClient processClient = kieClient.getServicesClient(ProcessServicesClient.class);
         List<ProcessInstance> instances = processClient.findProcessInstances(SOURCE_CONTAINER_ID, 0, 10);
         assertThat(instances, hasSize(1));
         assertThat(instances.get(0).getId(), is(2L));
-
+        assertCount(1, KIE_SERVER_ID, SOURCE_CONTAINER_ID);
         instances = processClient.findProcessInstances(TARGET_CONTAINER_ID, 0, 10);
         assertThat(instances, hasSize(1));
         assertThat(instances.get(0).getId(), is(1L));
+        assertCount(1, KIE_SERVER_ID, TARGET_CONTAINER_ID);
     }
 
-    private void startProcesses() throws InvalidKieServerException {
-        ProcessServicesClient client = kieService.getClient(KIE_SERVER_ID).getServicesClient(ProcessServicesClient.class);
+    private void startProcesses() {
+        ProcessServicesClient client = kieClient.getServicesClient(ProcessServicesClient.class);
         client.startProcess(SOURCE_CONTAINER_ID, PROCESS_ID);
         client.startProcess(SOURCE_CONTAINER_ID, PROCESS_ID);
     }
 
-    private Migration createMigration() throws IOException {
+    private void createMigration() throws IOException {
         Plan plan = createPlan();
         MigrationDefinition def = new MigrationDefinition();
         def.setPlanId(plan.getId());
@@ -131,7 +123,7 @@ class ProcessMigrationIT {
         String result = given()
                 .body(mapper.writeValueAsString(def))
                 .auth()
-                .basic(username, password)
+                .basic(PIM_USERNAME, PIM_PASSWORD)
                 .contentType(MediaType.APPLICATION_JSON)
                 .post("/rest/migrations")
                 .then()
@@ -149,8 +141,7 @@ class ProcessMigrationIT {
         assertThat(migration.getErrorMessage(), nullValue());
         assertThat(migration.getReports(), empty());
         assertThat(migration.getDefinition(), notNullValue());
-        assertThat(migration.getDefinition().getRequester(), is(username));
-        return migration;
+        assertThat(migration.getDefinition().getRequester(), is(PIM_USERNAME));
     }
 
     private Plan createPlan() throws IOException {
@@ -168,7 +159,7 @@ class ProcessMigrationIT {
                 .body(mapper.writeValueAsString(plan))
                 .contentType(MediaType.APPLICATION_JSON)
                 .auth()
-                .basic(username, password)
+                .basic(PIM_USERNAME, PIM_PASSWORD)
                 .post("/rest/plans")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
@@ -188,4 +179,29 @@ class ProcessMigrationIT {
         return resultPlan;
     }
 
+    private void assertCount(int size, String kieServerId, String containerId) {
+        given().get("/" + kieServerId + "/instances/" + containerId)
+                .then()
+                .statusCode(200)
+                .header("X-Total-Count", String.valueOf(size));
+    }
+
+    private KieServicesClient createClient() {
+        KieServicesConfiguration configuration = KieServicesFactory.newRestConfiguration(KIE_ENDPOINT, KIE_USERNAME, KIE_PASSWORD);
+        configuration.setTimeout(60000);
+        configuration.setMarshallingFormat(MarshallingFormat.JSON);
+        return KieServicesFactory.newKieServicesClient(configuration);
+    }
+
+    private File readFile(String resource) throws IOException {
+        File tmpFile = new File(resource);
+        tmpFile.deleteOnExit();
+        try (OutputStream os = new FileOutputStream(tmpFile)) {
+            InputStream is = ProcessMigrationIT.class.getResource("/kjars/" + resource).openStream();
+            byte[] buffer = new byte[is.available()];
+            is.read(buffer);
+            os.write(buffer);
+        }
+        return tmpFile;
+    }
 }

--- a/src/test/java/org/kie/processmigration/service/KieServiceImplTest.java
+++ b/src/test/java/org/kie/processmigration/service/KieServiceImplTest.java
@@ -185,8 +185,8 @@ class KieServiceImplTest {
 
     @Test
     void testCountRunningInstances() throws InvalidKieServerException {
-        assertThat(kieService.countRunningInstances("kie-server-1", "example-1.0.1"), is(10));
-        assertThat(kieService.countRunningInstances("kie-server-1", "example-2.0.1"), is(0));
+        assertThat(kieService.countRunningInstances("kie-server-1", "example-1.0.1"), is(10L));
+        assertThat(kieService.countRunningInstances("kie-server-1", "example-2.0.1"), is(0L));
     }
 
     private void assertSuccessConfig(KieServerConfig config) {

--- a/src/test/java/org/kie/processmigration/service/KieServiceImplTest.java
+++ b/src/test/java/org/kie/processmigration/service/KieServiceImplTest.java
@@ -167,13 +167,26 @@ class KieServiceImplTest {
 
     @Test
     void testGetRunningInstances() throws InvalidKieServerException {
-        assertThrows(InvalidKieServerException.class, () -> kieService.getRunningInstances("not-found", "foo", 0, 10));
-        List<RunningInstance> runningInstances = kieService.getRunningInstances("kie-server-2", "example-1.0.1", 0, 10);
+        assertThrows(InvalidKieServerException.class, () -> kieService.getRunningInstances("not-found", "foo", 0, 10, "", ""));
+        List<RunningInstance> runningInstances = kieService.getRunningInstances("kie-server-2", "example-1.0.1", 0, 10, "", "");
         assertThat(runningInstances, hasSize(1));
         RunningInstance instance = runningInstances.get(0);
         assertThat(instance.getId(), is(1));
         assertThat(instance.getStartTime(), notNullValue());
         assertThat(instance.getProcessInstanceId(), is(9L));
+
+        runningInstances = kieService.getRunningInstances("kie-server-2", "example-3.0.1", 0, 10, "startTime", "desc");
+        assertThat(runningInstances, hasSize(1));
+        instance = runningInstances.get(0);
+        assertThat(instance.getId(), is(1));
+        assertThat(instance.getStartTime(), notNullValue());
+        assertThat(instance.getProcessInstanceId(), is(9L));
+    }
+
+    @Test
+    void testCountRunningInstances() throws InvalidKieServerException {
+        assertThat(kieService.countRunningInstances("kie-server-1", "example-1.0.1"), is(10));
+        assertThat(kieService.countRunningInstances("kie-server-1", "example-2.0.1"), is(0));
     }
 
     private void assertSuccessConfig(KieServerConfig config) {

--- a/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
+++ b/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
@@ -43,9 +43,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.github.tomakehurst.wiremock.matching.MatchesJsonPathPattern;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -58,7 +56,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.okXml;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -82,14 +79,14 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
         stubFor(get(urlPathEqualTo(URI.create(server1Response.getResult().getLocation()).getPath()))
                 .withBasicAuth("admin", "admin123")
                 .willReturn(okJson(mapper.writeValueAsString(server1Response))));
-        stubCustomQueries(server1Response);
+        stubCountQuery(server1Response, "example-1.0.1", 10);
+        stubCountQuery(server1Response, "example-2.0.1", 0);
 
         ServiceResponse<KieServerInfo> server2Response = getResponseFor("kie-server-2");
         stubFor(get(urlPathEqualTo(URI.create(server2Response.getResult().getLocation()).getPath()))
                 .withBasicAuth("admin", "admin123")
                 .willReturn(okJson(mapper.writeValueAsString(server2Response))));
-        stubCustomQueries(server2Response);
-
+        
         ServiceResponse<KieServerInfo> vaultServerResponse = getResponseFor("vault");
         stubFor(get(urlPathEqualTo(URI.create(vaultServerResponse.getResult().getLocation()).getPath()))
                 .withBasicAuth("kieserver6", "kieserver6-password")
@@ -214,54 +211,36 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
         instance1.setState(1);
         instance1.setDate(new Date());
         ProcessInstanceList instances = new ProcessInstanceList(new ProcessInstance[]{instance1});
-        stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/containers/example-1.0.1/processes/instances"))
+        stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/queries/containers/example-1.0.1/process/instances"))
                 .withBasicAuth("admin", "admin123")
                 .withQueryParam("sort", new EqualToPattern("processInstanceId"))
                 .withQueryParam("sortOrder", new EqualToPattern("true"))
                 .withQueryParam("page", new EqualToPattern("0"))
                 .withQueryParam("pageSize", new EqualToPattern("10"))
+                .withQueryParam("status", new EqualToPattern("1"))
+                .withQueryParam("status", new EqualToPattern("0"))
+                .withQueryParam("status", new EqualToPattern("4"))
                 .willReturn(okJson(mapper.writeValueAsString(instances))));
 
-        stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/containers/example-3.0.1/processes/instances"))
+        stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/queries/containers/example-3.0.1/process/instances"))
                 .withBasicAuth("admin", "admin123")
                 .withQueryParam("sort", new EqualToPattern("start_date"))
                 .withQueryParam("sortOrder", new EqualToPattern("false"))
                 .withQueryParam("page", new EqualToPattern("0"))
                 .withQueryParam("pageSize", new EqualToPattern("10"))
+                .withQueryParam("status", new EqualToPattern("1"))
+                .withQueryParam("status", new EqualToPattern("0"))
+                .withQueryParam("status", new EqualToPattern("4"))
                 .willReturn(okJson(mapper.writeValueAsString(instances))));
     }
 
-    private void stubCustomQueries(ServiceResponse<KieServerInfo> response) {
+    private void stubCountQuery(ServiceResponse<KieServerInfo> response, String containerId, int count) {
         stubFor(get(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
-                + "/queries/definitions/countAllRunningInstances"))
-                .withBasicAuth("admin", "admin123")
-                .willReturn(notFound()));
-        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
-                + "/queries/definitions/countAllRunningInstances"))
-                .withBasicAuth("admin", "admin123")
-                .willReturn(ok()));
-        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
-                + "/queries/definitions/countAllRunningInstances/filtered-data"))
-                .withQueryParam("mapper", new EqualToPattern("RawList"))
-                .withQueryParam("page", new EqualToPattern("0"))
-                .withQueryParam("pageSize", new EqualToPattern("1"))
-                .withRequestBody(
-                        new MatchesJsonPathPattern("query-params[0]",
-                                new EqualToJsonPattern("{'cond-column': 'externalId', 'cond-operator': 'EQUALS_TO', 'cond-values': ['example-1.0.1']}",
-                                        true, false)))
-                .withBasicAuth("admin", "admin123")
-                .willReturn(ok("[[10.0]]")));
-        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
-                + "/queries/definitions/countAllRunningInstances/filtered-data"))
-                .withQueryParam("mapper", new EqualToPattern("RawList"))
-                .withQueryParam("page", new EqualToPattern("0"))
-                .withQueryParam("pageSize", new EqualToPattern("1"))
-                .withRequestBody(
-                        new MatchesJsonPathPattern("query-params[0]",
-                                new EqualToJsonPattern("{'cond-column': 'externalId', 'cond-operator': 'EQUALS_TO', 'cond-values': ['example-2.0.1']}",
-                                        true, false)))
-                .withBasicAuth("admin", "admin123")
-                .willReturn(ok()));
+                + "/queries/containers/" + containerId + "/process/instances/count"))
+                .withQueryParam("status", new EqualToPattern("1"))
+                .withQueryParam("status", new EqualToPattern("0"))
+                .withQueryParam("status", new EqualToPattern("4"))
+                .willReturn(ok("{\"count\": " + count + "}")));
     }
 
     public void enableRetryServer() throws JsonProcessingException {

--- a/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
+++ b/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
@@ -43,6 +43,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.MatchesJsonPathPattern;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -52,8 +55,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.forbidden;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.okXml;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -77,11 +82,13 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
         stubFor(get(urlPathEqualTo(URI.create(server1Response.getResult().getLocation()).getPath()))
                 .withBasicAuth("admin", "admin123")
                 .willReturn(okJson(mapper.writeValueAsString(server1Response))));
+        stubCustomQueries(server1Response);
 
         ServiceResponse<KieServerInfo> server2Response = getResponseFor("kie-server-2");
         stubFor(get(urlPathEqualTo(URI.create(server2Response.getResult().getLocation()).getPath()))
                 .withBasicAuth("admin", "admin123")
                 .willReturn(okJson(mapper.writeValueAsString(server2Response))));
+        stubCustomQueries(server2Response);
 
         ServiceResponse<KieServerInfo> vaultServerResponse = getResponseFor("vault");
         stubFor(get(urlPathEqualTo(URI.create(vaultServerResponse.getResult().getLocation()).getPath()))
@@ -200,7 +207,6 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
                 .withBasicAuth("admin", "admin123")
                 .willReturn(okXml("<test/>")));
 
-
         ProcessInstance instance1 = new ProcessInstance();
         instance1.setId(9L);
         instance1.setContainerId("example-1.0.1");
@@ -210,8 +216,52 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
         ProcessInstanceList instances = new ProcessInstanceList(new ProcessInstance[]{instance1});
         stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/containers/example-1.0.1/processes/instances"))
                 .withBasicAuth("admin", "admin123")
+                .withQueryParam("sort", new EqualToPattern("processInstanceId"))
+                .withQueryParam("sortOrder", new EqualToPattern("true"))
+                .withQueryParam("page", new EqualToPattern("0"))
+                .withQueryParam("pageSize", new EqualToPattern("10"))
                 .willReturn(okJson(mapper.writeValueAsString(instances))));
 
+        stubFor(get(urlPathEqualTo("/kie-server-2/services/rest/server/containers/example-3.0.1/processes/instances"))
+                .withBasicAuth("admin", "admin123")
+                .withQueryParam("sort", new EqualToPattern("start_date"))
+                .withQueryParam("sortOrder", new EqualToPattern("false"))
+                .withQueryParam("page", new EqualToPattern("0"))
+                .withQueryParam("pageSize", new EqualToPattern("10"))
+                .willReturn(okJson(mapper.writeValueAsString(instances))));
+    }
+
+    private void stubCustomQueries(ServiceResponse<KieServerInfo> response) {
+        stubFor(get(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
+                + "/queries/definitions/countAllRunningInstances"))
+                .withBasicAuth("admin", "admin123")
+                .willReturn(notFound()));
+        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
+                + "/queries/definitions/countAllRunningInstances"))
+                .withBasicAuth("admin", "admin123")
+                .willReturn(ok()));
+        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
+                + "/queries/definitions/countAllRunningInstances/filtered-data"))
+                .withQueryParam("mapper", new EqualToPattern("RawList"))
+                .withQueryParam("page", new EqualToPattern("0"))
+                .withQueryParam("pageSize", new EqualToPattern("1"))
+                .withRequestBody(
+                        new MatchesJsonPathPattern("query-params[0]",
+                                new EqualToJsonPattern("{'cond-column': 'externalId', 'cond-operator': 'EQUALS_TO', 'cond-values': ['example-1.0.1']}",
+                                        true, false)))
+                .withBasicAuth("admin", "admin123")
+                .willReturn(ok("[[10.0]]")));
+        stubFor(post(urlPathEqualTo(URI.create(response.getResult().getLocation()).getPath()
+                + "/queries/definitions/countAllRunningInstances/filtered-data"))
+                .withQueryParam("mapper", new EqualToPattern("RawList"))
+                .withQueryParam("page", new EqualToPattern("0"))
+                .withQueryParam("pageSize", new EqualToPattern("1"))
+                .withRequestBody(
+                        new MatchesJsonPathPattern("query-params[0]",
+                                new EqualToJsonPattern("{'cond-column': 'externalId', 'cond-operator': 'EQUALS_TO', 'cond-values': ['example-2.0.1']}",
+                                        true, false)))
+                .withBasicAuth("admin", "admin123")
+                .willReturn(ok()));
     }
 
     public void enableRetryServer() throws JsonProcessingException {


### PR DESCRIPTION
**JIRA**: 

[RHPAM-4028](https://issues.redhat.com/browse/RHPAM-4028)

Allow retrieving and selecting large number of instances.
The table now displays all the existing instances and pagination is now performed dynamically so that each page is loaded independently

**referenced Pull Requests**:

* Cherry-pick https://github.com/kiegroup/process-migration-service/pull/45