### PR TITLE
[BAQE-2276] - PIM needs to add support for other db certification (Postgresql plus)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,5 +820,17 @@
         <maven.skip.it.tests>true</maven.skip.it.tests>
       </properties>
     </profile>
+
+    <profile>
+      <id>other-database</id>
+      <activation>
+        <property>
+          <name>!maven.flyway.sql-prefix</name>
+        </property>
+      </activation>
+      <properties>
+        <maven.flyway.sql-prefix>${maven.jdbc.db-kind}</maven.flyway.sql-prefix>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/src/test/filtered-resources/application.yaml
+++ b/src/test/filtered-resources/application.yaml
@@ -9,7 +9,7 @@ quarkus:
     migrate-at-start: true
     baseline-version: 1.0
     baseline-description: PimDB
-    sql-migration-prefix: ${maven.jdbc.db-kind}
+    sql-migration-prefix: ${maven.flyway.sql-prefix}
     clean-at-start: true
     create-schemas: false
     schemas: "${maven.jdbc.schema}"


### PR DESCRIPTION
**[BAQE-2276](https://issues.redhat.com/browse/BAQE-2276)**: PIM needs to add support for other db certification (Postgresql plus)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/jboss-integration/bxms-qe-tests/pull/4108

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

</details>
