### PR TITLE
[JBPM-10073] - PIM on Quarkus 2.7.5 is failing to automatically create DB schemas through Flyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,10 @@ quarkus:
   flyway:
     connect-retries: 10
     table: flyway_pim_history
-    migrate-at-start: true
+    migrate-at-start: true (2)
     baseline-on-migrate: true
     baseline-version: 1.0
-    baseline-description: PimDB
-    sql-migration-prefix: h2 (2)        
+    baseline-description: PimDB      
 # Quartz configuration
   quartz:
     store-type: jdbc-cmt
@@ -181,7 +180,7 @@ pim:
 ```
 
 1. In case we wanted to enable a different database requiring a license agreement, the JDBC driver will have to be located in this `providers` folder manually.
-2. Flyway will automatically create PIM schema when enabled based on the DDL scripts prefix. Enabled by default.
+2. Out of the box, Flyway will automatically create PIM database schema for H2 in-memory database. Disable it (`-Dquarkus.flyway.migrate-at-start=false`) when you do not want PIM to handle the schema creation.
 3. Deploy the application on `/rest`
 4. H2 in-memory datasource. Override it by one of your choice
 5. Authentication method. Defaults to `file` but `jdbc` or `ldap` are also valid options
@@ -196,9 +195,10 @@ folder.
 
 As an example, if you want to replace the H2 default persistence configuration by 
 [MariaDB](./examples/persistence/mariadb.yml) and the authentication mechanism to use 
-[LDAP](examples/authentication/ldap/ldap.yml), see below.
+[LDAP](examples/authentication/ldap/ldap.yml), see sample config files below.
 
-**Note:** As the MariaDB jdbc driver is not included in the classpath. It must be added.
+- [MariaDB database configuration file](./examples/persistence/mariadb.yml)
+- [LDAP configuration file](examples/authentication/ldap/ldap.yml)
 
 **Note:** These files will override or extend the already defined properties in the application.yaml file
 
@@ -401,9 +401,8 @@ Note that in case of using a database requiring a JDBC driver license agreement 
 
 Afterwards, you can start up the application normally.
 ```shell script
-java -jar -Dquarkus.datasource.username=jbpm -Dquarkus.datasource.password=jbpm -Dquarkus.flyway.sql-migration-prefix=postgresql -Dquarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/jbpm?pinGlobalTxToPhysicalConnection=true target/quarkus-app/quarkus-run.jar
+java -jar -Dquarkus.flyway.migrate-at-start=false -Dquarkus.datasource.username=jbpm -Dquarkus.datasource.password=jbpm -Dquarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/jbpm?pinGlobalTxToPhysicalConnection=true target/quarkus-app/quarkus-run.jar
 ```
-Also, note that Flyway prefix property `quarkus.flyway.sql-migration-prefix` must be set accordingly to the right database used.
 
 Reference:
 
@@ -413,8 +412,8 @@ Reference:
 
 ## Disabling database schema auto-creation
 
-Process Migration service generates the database schema automatically if it is not already present by using the DDL scripts bundled in the application.
-You should be able to disable and manage the schema creation by disabling the `quarkus.flyway.migrate-at-start` property.
+By default, Process Migration service generates an in-memory database schema automatically.
+You should be able to disable it and manage the schema creation by setting and passing the `quarkus.flyway.migrate-at-start=false` system property.
 
 ```shell script
 java -jar -Dquarkus.flyway.migrate-at-start=false target/quarkus-app/quarkus-run.jar
@@ -428,7 +427,7 @@ property is changed at runtime. If you want to change a build-time property it i
 build.
 
 ```shell script
-java -jar -Dquarkus.launch.rebuild=true -Dquarkus.datasource.db-kind=mariadb -Dquarkus.flyway.sql-migration-prefix=mariadb target/quarkus-app/quarkus-run.jar
+java -jar -Dquarkus.launch.rebuild=true -Dquarkus.datasource.db-kind=mariadb target/quarkus-app/quarkus-run.jar
 ```
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -21,21 +21,32 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.skip.unit.tests>false</maven.skip.unit.tests>
     <maven.skip.it.tests>false</maven.skip.it.tests>
-    <version.com.fasterxml.jackson.core.jackson-databind>2.10.5.1</version.com.fasterxml.jackson.core.jackson-databind>
+    <version.com.fasterxml.jackson.core.jackson-databind>2.13.2.2</version.com.fasterxml.jackson.core.jackson-databind>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
-    <version.io.quarkus>2.2.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.7.5.Final</version.io.quarkus>
     <version.io.quarkiverse.file-vault>0.3.0</version.io.quarkiverse.file-vault>
     <version.org.github.tomakehurst.wiremock-jre8>2.27.2</version.org.github.tomakehurst.wiremock-jre8>
     <version.org.kie.server>${project.version}</version.org.kie.server>
     <version.org.mockito>3.7.7</version.org.mockito>
     <version.org.projectlombok.lombok>1.18.16</version.org.projectlombok.lombok>
+    <version.com.h2database>1.4.197</version.com.h2database>
+    <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Need to force the version of the maven-core artifact to be in sync with kie. Otherwise it might pick a wrong version coming from quarkus bom import -->
+    <version.org.codehaus.mojo.sql-maven-plugin>1.5</version.org.codehaus.mojo.sql-maven-plugin>
 
     <!-- Quarkus database setup -->
     <maven.jdbc.db-kind>h2</maven.jdbc.db-kind>
-    <maven.jdbc.url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</maven.jdbc.url>
+    <maven.jdbc.url>jdbc:h2:file:./target/testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE</maven.jdbc.url>
     <maven.jdbc.username>sa</maven.jdbc.username>
     <maven.jdbc.password>sa</maven.jdbc.password>
     <maven.jdbc.schema>PUBLIC</maven.jdbc.schema>
+    <maven.jdbc.driver.class>org.h2.Driver</maven.jdbc.driver.class>
+    <maven.jdbc.driver.path>/non-h2-driver-path-has-to-be-set</maven.jdbc.driver.path>
+    <maven.jdbc.pim.create-db-schema>true</maven.jdbc.pim.create-db-schema>
+    <maven.jdbc.pim.scripts.root.folder>${project.basedir}/ddl-scripts</maven.jdbc.pim.scripts.root.folder>
+    <maven.jdbc.pim.create.script.file>${maven.jdbc.pim.scripts.root.folder}/${maven.jdbc.db-kind}/${maven.jdbc.db-kind}-pim-schema.sql</maven.jdbc.pim.create.script.file>
+    <maven.jdbc.pim.drop.script.file>${maven.jdbc.pim.scripts.root.folder}/${maven.jdbc.db-kind}/${maven.jdbc.db-kind}-pim-drop-schema.sql</maven.jdbc.pim.drop.script.file>
+    <maven.jdbc.quartz.drop.script.file>${maven.jdbc.pim.scripts.root.folder}/${maven.jdbc.db-kind}/${maven.jdbc.db-kind}-quartz-drop-schema.sql</maven.jdbc.quartz.drop.script.file>
+    <maven.jdbc.quartz.create.script.file>${maven.jdbc.pim.scripts.root.folder}/${maven.jdbc.db-kind}/${maven.jdbc.db-kind}-quartz-schema.sql</maven.jdbc.quartz.create.script.file>
 
     <!-- Cargo plugin configuration -->
     <container.port>8080</container.port>
@@ -66,7 +77,6 @@
     <maven.pim.server.http.url>http://${maven.pim.server.host}:${maven.pim.server.http.port}</maven.pim.server.http.url>
     <maven.pim.server.http.health>${maven.pim.server.http.url}/q/health</maven.pim.server.http.health>
 
-    <maven.pim.flyway.prefix.version>1.0.0__</maven.pim.flyway.prefix.version>
   </properties>
 
   <repositories>
@@ -160,6 +170,12 @@
             <artifactId>cdi-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-core</artifactId>
+        <version>${version.org.apache.maven}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -331,6 +347,59 @@
         </includes>
       </testResource>
     </testResources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>sql-maven-plugin</artifactId>
+          <version>${version.org.codehaus.mojo.sql-maven-plugin}</version>
+          <!-- Driver we use to create PIM schema -->
+          <dependencies>
+            <dependency>
+              <groupId>com.h2database</groupId>
+              <artifactId>h2</artifactId>
+              <version>${version.com.h2database}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <driver>${maven.jdbc.driver.class}</driver>
+            <url>${maven.jdbc.url}</url>
+            <username>${maven.jdbc.username}</username>
+            <password>${maven.jdbc.password}</password>
+          </configuration>
+          <executions>
+            <execution>
+              <id>drop-pim-schema</id>
+              <phase>generate-test-resources</phase>
+              <goals>
+                <goal>execute</goal>
+              </goals>
+              <configuration>
+                <autocommit>true</autocommit>
+                <srcFiles>
+                  <srcFile>${maven.jdbc.pim.drop.script.file}</srcFile>
+                  <srcFile>${maven.jdbc.quartz.drop.script.file}</srcFile>
+                </srcFiles>
+              </configuration>
+            </execution>
+            <execution>
+              <id>create-pim-schema</id>
+              <phase>generate-test-resources</phase>
+              <goals>
+                <goal>execute</goal>
+              </goals>
+              <configuration>
+                <autocommit>true</autocommit>
+                <srcFiles>
+                  <srcFile>${maven.jdbc.quartz.create.script.file}</srcFile>
+                  <srcFile>${maven.jdbc.pim.create.script.file}</srcFile>
+                </srcFiles>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -464,6 +533,10 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>sql-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.bazaarvoice.maven.plugins</groupId>
@@ -628,33 +701,9 @@
             <phase>generate-resources</phase>
             <configuration>
               <target>
-                <concat destfile="${project.build.outputDirectory}/db/migration/h2/h2${maven.pim.flyway.prefix.version}pim-schema.sql">
+                <concat destfile="${project.build.outputDirectory}/db/migration/V1.0.0__h2-pim-schema.sql">
                   <fileset file="${project.basedir}/ddl-scripts/h2/h2-quartz-schema.sql" />
                   <fileset file="${project.basedir}/ddl-scripts/h2/h2-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/db2/db2${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/db2/db2-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/db2/db2-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/mariadb/mariadb${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/mariadb/mariadb-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/mariadb/mariadb-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/mssql/mssql${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/mssql/mssql-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/mssql/mssql-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/mysql/mysql${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/mysql/mysql-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/mysql/mysql-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/oracle/oracle${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/oracle/oracle-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/oracle/oracle-pim-schema.sql" />
-                </concat>
-                <concat destfile="${project.build.outputDirectory}/db/migration/postgresql/postgresql${maven.pim.flyway.prefix.version}pim-schema.sql">
-                  <fileset file="${project.basedir}/ddl-scripts/postgresql/postgresql-quartz-schema.sql" />
-                  <fileset file="${project.basedir}/ddl-scripts/postgresql/postgresql-pim-schema.sql" />
                 </concat>
               </target>
             </configuration>
@@ -819,6 +868,58 @@
       <properties>
         <maven.skip.it.tests>true</maven.skip.it.tests>
       </properties>
+    </profile>
+    <profile>
+      <!-- Need to load the appropriate driver for the particular DB to test based on a system path -->
+      <id>database</id>
+      <activation>
+        <property>
+          <name>maven.jdbc.db-kind</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>sql-maven-plugin</artifactId>
+              <version>${version.org.codehaus.mojo.sql-maven-plugin}</version>
+              <dependencies>
+                <dependency>
+                  <groupId>pim.database.driver</groupId>
+                  <artifactId>driver</artifactId>
+                  <scope>system</scope>
+                  <version>1.0</version>
+                  <systemPath>${maven.jdbc.driver.path}</systemPath>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>skip-db-schema-creation</id>
+      <activation>
+        <property>
+          <name>maven.jdbc.pim.create-db-schema</name>
+          <value>false</value>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>sql-maven-plugin</artifactId>
+              <version>${version.org.codehaus.mojo.sql-maven-plugin}</version>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,6 @@ quarkus:
     baseline-on-migrate: true
     baseline-version: 1.0
     baseline-description: PimDB
-    sql-migration-prefix: h2
   # Quartz configuration
   quartz:
     store-type: jdbc-cmt

--- a/src/test/filtered-resources/application.yaml
+++ b/src/test/filtered-resources/application.yaml
@@ -2,17 +2,9 @@ quarkus:
   log:
     level: INFO
     min-level: INFO
-  # flyway to create PIM schema
+  # Disabling flyway to test ddl scripts
   flyway:
-    connect-retries: 10
-    table: flyway_pim_history
-    migrate-at-start: true
-    baseline-version: 1.0
-    baseline-description: PimDB
-    sql-migration-prefix: ${maven.jdbc.db-kind}
-    clean-at-start: true
-    create-schemas: false
-    schemas: "${maven.jdbc.schema}"
+    migrate-at-start: false
   # Quartz configuration
   quartz:
     store-type: jdbc-cmt

--- a/src/test/java/org/kie/processmigration/persistence/DDLScriptsTest.java
+++ b/src/test/java/org/kie/processmigration/persistence/DDLScriptsTest.java
@@ -30,8 +30,7 @@ import javax.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
-import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.processmigration.listener.CountDownJobListener;
@@ -43,6 +42,7 @@ import org.kie.processmigration.model.Plan;
 import org.kie.processmigration.model.ProcessRef;
 import org.kie.processmigration.model.exceptions.InvalidMigrationException;
 import org.kie.processmigration.model.exceptions.MigrationNotFoundException;
+import org.kie.processmigration.model.exceptions.PlanNotFoundException;
 import org.kie.processmigration.service.KieService;
 import org.kie.processmigration.service.MigrationService;
 import org.kie.processmigration.service.PlanService;
@@ -99,13 +99,22 @@ public class DDLScriptsTest {
     @Inject
     Scheduler scheduler;
 
-    @Inject
-    Flyway flyway;
-
-    @AfterEach
+    @BeforeEach
     void cleanUp() {
-        flyway.clean();
-        flyway.migrate();
+        migrationService.findAll().forEach(migration -> {
+            try {
+                migrationService.delete(migration.getId());
+            } catch (MigrationNotFoundException e) {
+                // ignore
+            }
+        });
+        planService.findAll().forEach(plan -> {
+            try {
+                planService.delete(plan.getId());
+            } catch (PlanNotFoundException e) {
+                // ignore
+            }
+        });
     }
 
     static Stream<Execution> getExecutionTypes() {

--- a/src/test/java/org/kie/processmigration/service/MigrationServiceImplTest.java
+++ b/src/test/java/org/kie/processmigration/service/MigrationServiceImplTest.java
@@ -26,8 +26,7 @@ import javax.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
-import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.processmigration.model.Execution;
 import org.kie.processmigration.model.Migration;
@@ -79,13 +78,15 @@ class MigrationServiceImplTest {
     @InjectMock
     SchedulerService schedulerService;
 
-    @Inject
-    Flyway flyway;
-
-    @AfterEach
+    @BeforeEach
     void cleanUp() {
-        flyway.clean();
-        flyway.migrate();
+        migrationService.findAll().forEach(migration -> {
+            try {
+                migrationService.delete(migration.getId());
+            } catch (MigrationNotFoundException e) {
+                // ignore
+            }
+        });
     }
 
     @Test

--- a/src/test/java/org/kie/processmigration/service/PlanServiceImplTest.java
+++ b/src/test/java/org/kie/processmigration/service/PlanServiceImplTest.java
@@ -21,9 +21,9 @@ import java.util.List;
 import javax.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.flywaydb.core.Flyway;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.processmigration.model.Plan;
 import org.kie.processmigration.model.ProcessRef;
@@ -42,13 +42,15 @@ class PlanServiceImplTest {
     @Inject
     PlanService planService;
 
-    @Inject
-    Flyway flyway;
-
-    @AfterEach
+    @BeforeEach
     void cleanUp() {
-        flyway.clean();
-        flyway.migrate();
+        planService.findAll().forEach(plan -> {
+            try {
+                planService.delete(plan.getId());
+            } catch (PlanNotFoundException e) {
+                // ignore
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
**[JBPM-10073](https://issues.redhat.com/browse/JBPM-10073)**: PIM on Quarkus 2.7.5 is failing to automatically create DB schemas through Flyway

Referenced PR: https://github.com/jboss-integration/bxms-qe-tests/pull/4120

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

</details>
