### PR TITLE
[RHPAM-4544] Filter process instance id by source process id

### DIFF
--- a/src/main/java/org/kie/processmigration/service/impl/MigrationServiceImpl.java
+++ b/src/main/java/org/kie/processmigration/service/impl/MigrationServiceImpl.java
@@ -269,6 +269,7 @@ public class MigrationServiceImpl implements MigrationService {
             migration.getReports().stream().map(MigrationReport::getProcessInstanceId).forEach(migratedInstances::add);
         }
         Plan plan = planService.get(migration.getDefinition().getPlanId());
+        String processId = plan.getSource().getProcessId();
         if (instanceIds.isEmpty()) {
             boolean allFetched = false;
             int page = 0;
@@ -276,7 +277,7 @@ public class MigrationServiceImpl implements MigrationService {
                 List<ProcessInstance> instances = kieService.getQueryServicesClient(migration.getDefinition().getKieServerId())
                         .findProcessInstancesByContainerId(plan.getSource().getContainerId(), QUERY_PROCESS_INSTANCE_STATUSES, page++, QUERY_PAGE_SIZE);
 
-                instances.forEach(p -> instanceIds.add(p.getId()));
+                instances.stream().filter(p -> processId.equals(p.getProcessId())).map(ProcessInstance::getId).forEach(instanceIds::add);
                 if (instances.size() < QUERY_PAGE_SIZE) {
                     allFetched = true;
                 }

--- a/src/test/java/org/kie/processmigration/service/MigrationServiceImplTest.java
+++ b/src/test/java/org/kie/processmigration/service/MigrationServiceImplTest.java
@@ -181,6 +181,7 @@ class MigrationServiceImplTest {
         ProcessInstance instance = new ProcessInstance();
         instance.setId(2L);
         instance.setContainerId("source-container");
+        instance.setProcessId("source-process");
         instances.add(instance);
         when(mockQueryServicesClient.findProcessInstancesByContainerId(eq(plan.getSource().getContainerId()), anyList(), anyInt(), anyInt())).thenReturn(instances);
         when(mockQueryServicesClient.findProcessInstanceById(instance.getId())).thenReturn(instance);


### PR DESCRIPTION
When running against all available instances (empty processInstanceIds array) select only instances that matches with source process definition

**JIRA**: [RHPAM-4544](https://issues.redhat.com/browse/RHPAM-4544)

**referenced Pull Requests**: NO

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

</details>
