### PR TITLE
[BXMSPROD-1700] @kie/lock-treatment-tool removed from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,7 @@
     "build": "webpack -p",
     "start": "node src/bin/server.js",
     "test": "jest",
-    "precommit": "lint-staged",
-    "locktt": "locktt"
+    "precommit": "lint-staged"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [
@@ -27,7 +26,6 @@
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@kie/lock-treatment-tool": "^0.1.0",
     "axios": "^0.21.4",
     "babel-eslint": "^10.0.2",
     "babel-jest": "^24.8.0",

--- a/pom.xml
+++ b/pom.xml
@@ -623,7 +623,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>exec @kie/lock-treatment-tool --</arguments>
+              <arguments>exec @kie/lock-treatment-tool@^0.2.2 --</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1700

- https://github.com/kiegroup/appformer/pull/1319
- https://github.com/kiegroup/kie-wb-common/pull/3784
- https://github.com/kiegroup/optaweb-employee-rostering/pull/858
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/775
- https://github.com/kiegroup/process-migration-service/pull/79