### PR TITLE
RHPAM-4608 - Transaction isolation - upgrade DDL scripts fixes

### DIFF
--- a/upgrade-scripts/db2/pim-7.71-to-7.73.sql
+++ b/upgrade-scripts/db2/pim-7.71-to-7.73.sql
@@ -1,0 +1,2 @@
+alter table migration_reports
+  drop foreign key FK98ckwvu4fyt55u6sq680xwkmx;

--- a/upgrade-scripts/db2/rhpam-7.12-to-7.13.sql
+++ b/upgrade-scripts/db2/rhpam-7.12-to-7.13.sql
@@ -1,0 +1,2 @@
+alter table migration_reports
+  drop foreign key FK98ckwvu4fyt55u6sq680xwkmx;

--- a/upgrade-scripts/mariadb/pim-7.71-to-7.73.sql
+++ b/upgrade-scripts/mariadb/pim-7.71-to-7.73.sql
@@ -1,2 +1,2 @@
-alter table if exists migration_reports
+alter table migration_reports
   drop foreign key if exists FK98ckwvu4fyt55u6sq680xwkmx;

--- a/upgrade-scripts/mariadb/rhpam-7.12-to-7.13.sql
+++ b/upgrade-scripts/mariadb/rhpam-7.12-to-7.13.sql
@@ -1,2 +1,2 @@
-alter table if exists migration_reports
+alter table migration_reports
   drop foreign key if exists FK98ckwvu4fyt55u6sq680xwkmx;


### PR DESCRIPTION
**JIRA:** [RHPAM-4608]( https://issues.redhat.com/browse/RHPAM-4608)

* DB2 Upgrade scripts were missing
* MariaDB supports `ALTER TABLE IF EXISTS` only from [10.5.2](https://mariadb.com/kb/en/mariadb-1052-release-notes/) on

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

</details>
