### PR TITLE
[7.67.x-blue] RHPAM-3709: upgrade maven dependencies to address CVE-2021-26291

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.org.mockito>3.7.7</version.org.mockito>
     <version.org.projectlombok.lombok>1.18.16</version.org.projectlombok.lombok>
     <h2.version>2.1.214</h2.version>
-    <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Need to force the version of the maven-core artifact to be in sync with kie. Otherwise it might pick a wrong version coming from quarkus bom import -->
+    <version.org.apache.maven>3.8.6</version.org.apache.maven> <!-- Need to force the version of the maven-core artifact to be in sync with kie. Otherwise it might pick a wrong version coming from quarkus bom import -->
     <version.org.codehaus.mojo.sql-maven-plugin>1.5</version.org.codehaus.mojo.sql-maven-plugin>
     <version.cargo-maven3-plugin>1.10.4</version.cargo-maven3-plugin>
     <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Replaces https://github.com/kiegroup/process-migration-service/pull/133