### PR TITLE
[7.67.x-blue] upgrade sshd-common version from 2.10.0 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,17 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-elytron-security-ldap</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-common</artifactId>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The current sshd-common version `2.10.0.redhat-00002` is affected by [CVE-2024-41909]
Updating sshd-common to ´2.12.0´ resolves the CVE
