### PR TITLE
[7.67.x-blue] upgrade vertx-web and vertx-core to versions 4.3.8 and 4.5.3 respectively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,26 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-web</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>4.3.8</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
     <version.org.codehaus.mojo.sql-maven-plugin>1.5</version.org.codehaus.mojo.sql-maven-plugin>
     <version.cargo-maven3-plugin>1.10.4</version.cargo-maven3-plugin>
     <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
+    <version.io.vertx-web>4.3.8</version.io.vertx-web>
+    <version.io.vertx-core>4.5.3</version.io.vertx-core>
 
     <!-- Quarkus database setup -->
     <maven.jdbc.db-kind>h2</maven.jdbc.db-kind>
@@ -222,12 +224,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>4.5.3</version>
+      <version>${version.io.vertx-core}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>4.3.8</version>
+      <version>${version.io.vertx-web}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The current vertx-web version 4.3.4.redhat-00008 is affected by [CVE-2023-24815] and current vertx-core version 4.3.4.redhat-00008 is affected by [CVE-2024-1300]
Updating vertx-web to´4.3.8´ and vertx-core to `4.5.3` resolves the CVE