### PR TITLE
DBACLD-201782: [CVE] Update jackson-core to at least 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <maven.skip.unit.tests>false</maven.skip.unit.tests>
     <maven.skip.it.tests>false</maven.skip.it.tests>
     <version.com.fasterxml.jackson.core.jackson-databind>2.15.0</version.com.fasterxml.jackson.core.jackson-databind>
+    <version.com.fasterxml.jackson.core>2.15.0</version.com.fasterxml.jackson.core>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
     <version.io.quarkus>2.13.9.Final</version.io.quarkus>
     <version.io.quarkiverse.file-vault>0.7.1</version.io.quarkiverse.file-vault>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.skip.unit.tests>false</maven.skip.unit.tests>
     <maven.skip.it.tests>false</maven.skip.it.tests>
-    <version.com.fasterxml.jackson.core.jackson-databind>2.18.4</version.com.fasterxml.jackson.core.jackson-databind>
+    <version.com.fasterxml.jackson.core.jackson-databind>2.15.0</version.com.fasterxml.jackson.core.jackson-databind>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
     <version.io.quarkus>2.13.9.Final</version.io.quarkus>
     <version.io.quarkiverse.file-vault>0.7.1</version.io.quarkiverse.file-vault>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.skip.unit.tests>false</maven.skip.unit.tests>
     <maven.skip.it.tests>false</maven.skip.it.tests>
-    <version.com.fasterxml.jackson.core.jackson-databind>2.13.4.2</version.com.fasterxml.jackson.core.jackson-databind>
+    <version.com.fasterxml.jackson.core.jackson-databind>2.18.4</version.com.fasterxml.jackson.core.jackson-databind>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
     <version.io.quarkus>2.13.9.Final</version.io.quarkus>
     <version.io.quarkiverse.file-vault>0.7.1</version.io.quarkiverse.file-vault>

--- a/src/main/java/org/kie/processmigration/rest/provider/ObjectMapperContextResolver.java
+++ b/src/main/java/org/kie/processmigration/rest/provider/ObjectMapperContextResolver.java
@@ -19,6 +19,7 @@ package org.kie.processmigration.rest.provider;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -32,6 +33,8 @@ public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }
 
     @Override

--- a/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
+++ b/src/test/java/org/kie/processmigration/integration/ProcessMigrationIT.java
@@ -50,7 +50,7 @@ import org.kie.server.client.KieServicesFactory;
 import org.kie.server.client.ProcessServicesClient;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -71,7 +71,10 @@ class ProcessMigrationIT extends AbstractBaseIT {
     private static final String TARGET_CONTAINER_ID = "test_2.0.0";
 
     private KieServicesClient kieClient;
-    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+    private final ObjectMapper mapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
 
     @BeforeEach
     void deployProcesses() throws IOException {

--- a/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
+++ b/src/test/java/org/kie/processmigration/test/MockKieServerLifecycleManager.java
@@ -40,6 +40,7 @@ import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.ProcessInstanceList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -66,7 +67,10 @@ public class MockKieServerLifecycleManager implements QuarkusTestResourceLifecyc
 
     private WireMockServer wireMockServer;
 
-    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JaxbAnnotationModule());
+    private final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JaxbAnnotationModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
 
     @SneakyThrows
     @Override


### PR DESCRIPTION
closes [DBACLD-201782](https://jsw.ibm.com/browse/DBACLD-201782),

Updated jackson-core to 2.15.0