### PR TITLE
[7.67.x-blue] Fix CVE-2025-59250: Update mssql-jdbc to 11.2.4.jre11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <version.org.mockito>3.7.7</version.org.mockito>
     <version.org.projectlombok.lombok>1.18.16</version.org.projectlombok.lombok>
     <h2.version>2.1.214</h2.version>
+    <version.com.microsoft.sqlserver.mssql-jdbc>11.2.4.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
     <version.org.apache.maven>3.8.6</version.org.apache.maven> <!-- Need to force the version of the maven-core artifact to be in sync with kie. Otherwise it might pick a wrong version coming from quarkus bom import -->
     <version.org.codehaus.mojo.sql-maven-plugin>1.5</version.org.codehaus.mojo.sql-maven-plugin>
     <version.cargo-maven3-plugin>1.10.4</version.cargo-maven3-plugin>
@@ -126,7 +127,7 @@
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
-        <version>11.2.4.jre11</version>
+        <version>${version.com.microsoft.sqlserver.mssql-jdbc}</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Override Quarkus BOM version to fix CVE-2025-59250 -->
+      <dependency>
+        <groupId>com.microsoft.sqlserver</groupId>
+        <artifactId>mssql-jdbc</artifactId>
+        <version>11.2.4.jre11</version>
+      </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,16 @@
         <artifactId>jackson-databind</artifactId>
         <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${version.com.fasterxml.jackson.core}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${version.com.fasterxml.jackson.core}</version>
+      </dependency>
       <!--  droolsjbpm-integration dependencies- end -->
       <dependency>
         <groupId>org.kie.soup</groupId>


### PR DESCRIPTION
closes [DBACLD-201772](https://jsw.ibm.com/browse/DBACLD-201772)
Override Quarkus BOM to use patched mssql-jdbc version.