### PR TITLE
Fix CVE-2025-58057, CVE-2025-58056: Update netty to 4.1.128.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.128.Final</version>
+        <version>${version.io.netty}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
     <version.org.codehaus.mojo.sql-maven-plugin>1.5</version.org.codehaus.mojo.sql-maven-plugin>
     <version.cargo-maven3-plugin>1.10.4</version.cargo-maven3-plugin>
     <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
-    <version.io.netty>4.1.118.Final</version.io.netty>
+    <!-- Netty version to fix CVE-2025-58057, CVE-2025-58056, CVE-2025-55163 -->
+    <version.io.netty>4.1.128.Final</version.io.netty>
 
     <!-- Quarkus database setup -->
     <maven.jdbc.db-kind>h2</maven.jdbc.db-kind>
@@ -115,28 +116,21 @@
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>
       </dependency>	    
+      <!-- Import netty-bom BEFORE Quarkus BOM to ensure precedence -->
+      <!-- Fixes CVE-2025-58057, CVE-2025-58056, CVE-2025-55163 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.128.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${version.io.quarkus}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <!-- Override Quarkus BOM versions to fix CVE-2025-58057, CVE-2025-58056 -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.128.Final</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http</artifactId>
-        <version>4.1.128.Final</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec</artifactId>
-        <version>4.1.128.Final</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,22 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Override Quarkus BOM versions to fix CVE-2025-58057, CVE-2025-58056 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>4.1.128.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>4.1.128.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>4.1.128.Final</version>
+      </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>


### PR DESCRIPTION
closes [DBACLD-199586](https://jsw.ibm.com/browse/DBACLD-199586)

Ensemble PR: kiegroup/jbpm-work-items#331