### PR TITLE
[7.67.x-blue]Update plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
     <!-- Netty version to fix CVE-2025-58057, CVE-2025-58056, CVE-2025-55163 -->
     <version.io.netty>4.1.128.Final</version.io.netty>
+    <version.org.codehaus.plexus.plexus-utils>3.6.1</version.org.codehaus.plexus.plexus-utils>
 
     <!-- Quarkus database setup -->
     <maven.jdbc.db-kind>h2</maven.jdbc.db-kind>
@@ -219,7 +220,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.6.1</version>
+        <version>${version.org.codehaus.plexus.plexus-utils}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
         <version>${version.org.apache.maven}</version>
         <scope>test</scope>
       </dependency>
+      <!-- Override plexus-utils to fix CVE -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]
Linked PR : https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2665