### PR TITLE
[7.67.x-blue] Update jackson core version to 2.18.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.skip.unit.tests>false</maven.skip.unit.tests>
     <maven.skip.it.tests>false</maven.skip.it.tests>
     <version.com.fasterxml.jackson.core.jackson-databind>2.15.0</version.com.fasterxml.jackson.core.jackson-databind>
-    <version.com.fasterxml.jackson.core>2.15.0</version.com.fasterxml.jackson.core>
+    <version.com.fasterxml.jackson.core>2.18.6</version.com.fasterxml.jackson.core>
     <version.frontend.plugin>1.12.0</version.frontend.plugin>
     <version.io.quarkus>2.13.9.Final</version.io.quarkus>
     <version.io.quarkiverse.file-vault>0.7.1</version.io.quarkiverse.file-vault>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
         <version>${version.org.apache.maven}</version>
         <scope>test</scope>
       </dependency>
+      <!-- Override plexus-utils to fix CVE -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,6 @@
         <version>${version.org.apache.maven}</version>
         <scope>test</scope>
       </dependency>
-      <!-- Override plexus-utils to fix CVE -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.6.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Updating jackson_core version to 2.18.6 resolves the [https://github.com/advisories/GHSA-72hv-8253-57qq]
Linked PR : https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2668